### PR TITLE
Fix unmatch between the ignored gt points and predictions

### DIFF
--- a/utils/eval_np.py
+++ b/utils/eval_np.py
@@ -220,7 +220,6 @@ class Panoptic4DEval:
     self.preds = {}
     self.gts = {}
     self.intersects = {}
-    self.intersects_ovr = {}
 
     # Per-class association quality collect here
     self.pan_aq = np.zeros(self.n_classes, dtype=np.double)
@@ -289,19 +288,22 @@ class Panoptic4DEval:
       else:
         stat_dict[uniqueid] = counts
 
+  def makeGloballyUniqueInstanceIds(self, sem_labels, inst_labels):
+      non_instance_mask = inst_labels == 0
+      global_inst_labels = (sem_labels << 16) + inst_labels
+      global_inst_labels[non_instance_mask] = 0
+      return global_inst_labels
+
   def addBatchPanoptic4D(self, seq, x_sem_row, x_inst_row, y_sem_row, y_inst_row):
+    # first convert the gt instance labels to globally unique instance labels
+    y_inst_row = self.makeGloballyUniqueInstanceIds(y_sem_row, y_inst_row)
 
     #start = time.time()
     if seq not in self.sequences:
       self.sequences.append(seq)
       self.preds[seq] = {}
-      self.gts[seq] = [{} for i in range(self.n_classes)]
-      self.intersects[seq] = [{} for i in range(self.n_classes)]
-      self.intersects_ovr[seq] = [{} for i in range(self.n_classes)]
-
-    # make sure instances are not zeros (it messes with my approach)
-    x_inst_row = x_inst_row + 1
-    y_inst_row = y_inst_row + 1
+      self.gts[seq] = {}
+      self.intersects[seq] = {}
 
     # only interested in points that are outside the void area (not in excluded classes)
     for cl in self.ignore:
@@ -313,94 +315,79 @@ class Panoptic4DEval:
       x_inst_row = x_inst_row[gt_not_in_excl_mask]
       y_inst_row = y_inst_row[gt_not_in_excl_mask]
 
-    for cl in self.include:
-      # print("*"*80)
-      # print("CLASS", cl.item())
+    # Per-class accumulated stats
+    preds = self.preds[seq]
+    gts = self.gts[seq]
+    intersects = self.intersects[seq]
 
-      # Per-class accumulated stats
-      cl_preds = self.preds[seq]
-      cl_gts = self.gts[seq][cl]
-      cl_intersects = self.intersects[seq][cl]
+    # generate the areas for each unique instance gt_np (i.e., set2)
+    unique_gt, counts_gt = np.unique(y_inst_row[y_inst_row > 0], return_counts=True)
 
-      # get a binary class mask (filter acc. to semantic class!)
-      x_inst_in_cl_mask = x_sem_row == cl
-      y_inst_in_cl_mask = y_sem_row == cl
+    # generate ignore mask for the gt instances that have no more than self.min points
+    mask_gt_ignored_point = np.zeros_like(y_inst_row)
+    for valid_id in unique_gt[counts_gt <= self.min_points]:
+        mask_gt_ignored_point = np.logical_or(
+            mask_gt_ignored_point, y_inst_row == valid_id
+        )
 
-      # get instance points in class (mask-out everything but _this_ class)
-      x_inst_in_cl = x_inst_row * x_inst_in_cl_mask.astype(np.int64)
-      y_inst_in_cl = y_inst_row * y_inst_in_cl_mask.astype(np.int64)
+    # remove the ignored points, just like what we did for classes in self.ignore
+    y_inst_row = y_inst_row[np.logical_not(mask_gt_ignored_point)]
+    x_inst_row = x_inst_row[np.logical_not(mask_gt_ignored_point)]
 
-      # generate the areas for each unique instance gt_np (i.e., set2)
-      unique_gt, counts_gt = np.unique(y_inst_in_cl[y_inst_in_cl > 0], return_counts=True)
-      self.update_dict_stat(cl_gts, unique_gt[counts_gt>self.min_points], counts_gt[counts_gt>self.min_points])
+    # for the clarity, re-count the gt unique instances
+    unique_gt, counts_gt = np.unique(y_inst_row[y_inst_row > 0], return_counts=True)
+    # record gt instances
+    self.update_dict_stat(gts, unique_gt, counts_gt)
 
-      ### additionally here should be a mask for the filtered gt points that have no more than self.min points
-      ### because we want to actually ignore them in the metrics calculation
-      ### thus we should also mask out the corresponding predictions
-      ### otherwise the predictions on the ignored points would actually affect the metrics by causing a mismatch between the gt_size and pred_size, which is not desired
-      mask_gt_min_point = np.zeros_like(y_inst_in_cl)
-      for valid_id in unique_gt[counts_gt <= self.min_points]:
-          mask_gt_min_point = np.logical_or(
-              mask_gt_min_point, y_inst_in_cl == valid_id
-          )
+    # generate the areas for each unique instance prediction (i.e., set1)
+    unique_pred, counts_pred = np.unique(
+        x_inst_row[x_inst_row > 0], return_counts=True
+    )
+    # record prediction instances
+    self.update_dict_stat(preds, unique_pred, counts_pred)
 
-      valid_combos_min_point = np.zeros_like(y_inst_in_cl)  # instances which have more than self.min points
-      for valid_id in unique_gt[counts_gt > self.min_points]:
-        valid_combos_min_point = np.logical_or(valid_combos_min_point, y_inst_in_cl == valid_id)
+    valid_combos = np.logical_and(
+        x_inst_row > 0, y_inst_row > 0
+    )  # Convert to boolean and do logical and, based on semantics
 
-      y_inst_in_cl = y_inst_in_cl * valid_combos_min_point
-      # generate the areas for each unique instance prediction (i.e., set1)
-      ### here we should mask out the predictions that correspond to the ignored gt instances
-      x_inst_in_cl = x_inst_in_cl * np.logical_not(mask_gt_min_point)
-      unique_pred, counts_pred = np.unique(x_inst_in_cl[x_inst_in_cl > 0], return_counts=True)
+    # generate intersection using offset
+    offset_combo = x_inst_row[valid_combos] + self.offset * y_inst_row[valid_combos]
+    unique_combo, counts_combo = np.unique(offset_combo, return_counts=True)
 
-      # is there better way to do this?
-      self.update_dict_stat(cl_preds, unique_pred, counts_pred)
-
-      valid_combos = np.logical_and(x_inst_row > 0,
-                                    y_inst_in_cl > 0)  # Convert to boolean and do logical and, based on semantics
-
-      # generate intersection using offset
-      offset_combo = x_inst_row[valid_combos] + self.offset * y_inst_in_cl[valid_combos]
-      unique_combo, counts_combo = np.unique(offset_combo, return_counts=True)
-
-      self.update_dict_stat(cl_intersects, unique_combo, counts_combo)
+    self.update_dict_stat(intersects, unique_combo, counts_combo)
 
 
   def getPQ4D(self):
     precs = []
     recalls = []
-    num_tubes = [0] * self.n_classes
+    num_tubes = 0
     for seq in self.sequences:
-      for cl in self.include:
-        cl_preds = self.preds[seq]
-        cl_gts = self.gts[seq][cl]
-        cl_intersects = self.intersects[seq][cl]
-        outer_sum_iou = 0.0
-        num_tubes[cl] += len(cl_gts)
-        for gt_id, gt_size in cl_gts.items():
-          inner_sum_iou = 0.0
-          for pr_id, pr_size in cl_preds.items():
-            # TODO: pay attention for zero intersection!
-            TPA_key =  pr_id + self.offset * gt_id
-            if TPA_key in cl_intersects:
-              TPA = cl_intersects[TPA_key]
-              Prec = TPA / float(pr_size) # TODO I dont think these can ever be zero, but double check
-              Recall = TPA / float(gt_size)
-              precs.append(Prec)
-              recalls.append(Recall)
-              TPA_ovr = self.intersects[seq][cl][TPA_key]
-              inner_sum_iou += TPA_ovr * (TPA_ovr / (gt_size + pr_size - TPA_ovr))
-              if Prec > 1.0 or Recall >1.0:
-                print ('something wrong !!')
-          outer_sum_iou += 1.0 / float(gt_size) * float(inner_sum_iou)
-        self.pan_aq[cl] += outer_sum_iou # 1.0/float(len(cl_gts)) # Normalize by #tubes
-        self.pan_aq_ovr += outer_sum_iou
+      preds = self.preds[seq]
+      gts = self.gts[seq]
+      intersects = self.intersects[seq]
+      outer_sum_iou = 0.0
+      num_tubes += len(gts)
+      for gt_id, gt_size in gts.items():
+        inner_sum_iou = 0.0
+        for pr_id, pr_size in preds.items():
+          # TODO: pay attention for zero intersection!
+          TPA_key =  pr_id + self.offset * gt_id
+          if TPA_key in intersects:
+            TPA = intersects[TPA_key]
+            Prec = TPA / float(pr_size) # TODO I dont think these can ever be zero, but double check
+            Recall = TPA / float(gt_size)
+            precs.append(Prec)
+            recalls.append(Recall)
+            TPA_ovr = self.intersects[seq][TPA_key]
+            inner_sum_iou += TPA_ovr * (TPA_ovr / (gt_size + pr_size - TPA_ovr))
+            if Prec > 1.0 or Recall >1.0:
+              print ('something wrong !!')
+        outer_sum_iou += 1.0 / float(gt_size) * float(inner_sum_iou)
+      self.pan_aq_ovr += outer_sum_iou
     # ==========
 
     #print ('num tubes:', len(list(cl_preds.items())))
-    AQ_overall = np.sum(self.pan_aq_ovr)/ np.sum(num_tubes[1:9])
-    AQ = self.pan_aq / np.maximum(num_tubes, self.eps)
+    AQ_overall = np.sum(self.pan_aq_ovr)/ num_tubes
 
     iou_mean, iou, iou_p, iou_r = self.getSemIoU()
 
@@ -408,7 +395,7 @@ class Panoptic4DEval:
     AQ_r = np.mean(recalls)
 
     PQ4D =  math.sqrt(AQ_overall*iou_mean)
-    return PQ4D, AQ_overall, AQ, AQ_p, AQ_r,  iou, iou_mean, iou_p, iou_r
+    return PQ4D, AQ_overall, AQ_p, AQ_r,  iou, iou_mean, iou_p, iou_r
 
 
   #############################  Panoptic STUFF ################################

--- a/utils/evaluate_4dpanoptic.py
+++ b/utils/evaluate_4dpanoptic.py
@@ -185,7 +185,7 @@ if __name__ == '__main__':
   print("100%")
 
   complete_time = time.time() - start_time
-  LSTQ, LAQ_ovr, LAQ, AQ_p, AQ_r,  iou, iou_mean, iou_p, iou_r = class_evaluator.getPQ4D()
+  LSTQ, LAQ_ovr, AQ_p, AQ_r,  iou, iou_mean, iou_p, iou_r = class_evaluator.getPQ4D()
   things_iou = iou[1:9].mean()
   stuff_iou = iou[9:].mean()
   print ("=== Results ===")
@@ -193,7 +193,6 @@ if __name__ == '__main__':
   print("S_assoc (LAQ):", LAQ_ovr)
   float_formatter = "{:.2f}".format
   np.set_printoptions(formatter={'float_kind': float_formatter})
-  print ("Assoc:", LAQ)
   print ("iou:", iou)
   print("things_iou:", things_iou)
   print("stuff_iou:", stuff_iou)


### PR DESCRIPTION
This is a fix for the issue of mismatch between the ignored gt points and predictions. Also see [this issue](https://github.com/MehmetAygun/4D-PLS/issues/14#issue-1813808156) for the context.

I notice that you ignored the gt instances with less then 50 points by not adding them to the `cl_gts`. Thus, whatever the preditions think of these points, it should not bring any difference. However, you did not ignore the corresponding predictions and added them to the `cl_preds`. As a result, this caused a mismatch between the volumn of preds and gts.

To further explain my point, you can test it by sending in gt as predictions. To do that, we need to insert
```python
    u_pred_noninstance_mask = u_pred_inst==0
    u_pred_inst = (u_pred_sem_class << 16) + u_pred_inst
    u_pred_inst[u_pred_noninstance_mask] = 0
```
after [this line](https://github.com/MehmetAygun/4D-PLS/blob/7bfc49f0fad6c9fc855c241aa9545697fd8a8121/utils/evaluate_4dpanoptic.py#L178) to create globally unique prediction instance ids even across different categories.  Then you run the evaluation and it should give you perfect 1.0 scores.

With the unfixed version, if you also send the gt as predictions following the process above, you should get lower precision, because the corresponding points in gt for some predictions were removed and that implicitly means "you predicted something incorrectly", while on the other hand the predictions are indeed correct but just do not have counterpart since you haven't recorded them.

Update:
I notice that this per-class processing is error-prone and unclear. I further remove the need for a per-class processing by constructing a globally unique id for each gt instance at the beginning of the `addBatchPanoptic4D` method. It clarifies the picture and also *largely* decreases the evaluation time. The only impact to the overall pipeline is that AQ per class is not available. But I guess this is fine since in the paper it says the AQ should be class-agnostic anyway.